### PR TITLE
Grafana

### DIFF
--- a/tf/grafana-db/.terraform.lock.hcl
+++ b/tf/grafana-db/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.46.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:GK1y1qAGcPHPZxz01Ko6v+815T7kZPXt6POBsLg9c/k=",
+    "zh:05ae6180a7f23071435f6e5e59c19af0b6c5da42ee600c6c1568c8660214d548",
+    "zh:0d878d1565d5e57ce6b34ec5f04b28662044a50c999ec5770c374aa1f1020de2",
+    "zh:25ef1467af2514d8011c44759307445f7057836ff87dfe4503c3e1c9776d5c1a",
+    "zh:26c006df6200f0063b827aab05bec94f9f3f77848e82ed72e48a51d1170d1961",
+    "zh:37cdf4292649a10f12858622826925e18ad4eca354c31f61d02c66895eb91274",
+    "zh:4315b0433c2fc512666c74e989e2d95240934ef370bea1c690d36cb02d30c4ce",
+    "zh:75df0b3f631b78aeff1832cc77d99b527c2a5e79d40f7aac40bdc4a66124dac2",
+    "zh:90693d936c9a556d2bf945de4920ff82052002eb73139bd7164fafd02920f0ef",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c9177ad09804c60fd2ed25950570407b6bdcdf0fcc309e1673b584f06a827fae",
+    "zh:ca8e8db24a4d62d92afd8d3d383b81a08693acac191a2e0a110fb46deeff56a3",
+    "zh:d5fa3a36e13957d63bfe9bbd6df0426a2422214403aac9f20b60c36f8d9ebec6",
+    "zh:e4ede44a112296c9cc77b15e439e41ee15c0e8b3a0dec94ae34df5ebba840e8b",
+    "zh:f2d4de8d8cde69caffede1544ebea74e69fcc4552e1b79ae053519a05c060706",
+    "zh:fc19e9266b1841d4a3aeefa8a5b5ad6988baed6540f85a373b6c2d0dc1ca5830",
+  ]
+}

--- a/tf/grafana-db/README.md
+++ b/tf/grafana-db/README.md
@@ -1,0 +1,26 @@
+Apply this module before `tf/grafana`.
+
+## DB initialization
+
+Run on bastion:
+
+```
+mysql -urk -phimitsudayo -h grafana1.db.apne1.rubykaigi.net
+```
+
+```sql
+ set password = '{rk user password}';
+create user grafana@"%" identified by '{random password}';
+grant all on grafana.* to grafana@"%";
+flush privileges;
+```
+
+Create secret:
+
+```
+ ( umask 0066; echo -n '{password}' > /tmp/sec )
+kubectl create secret generic grafana-mysql --from-literal=username=grafana --from-file=password=/tmp/sec
+shred --remove /tmp/sec
+```
+
+Than apply `tf/grafana`.

--- a/tf/grafana-db/aws.tf
+++ b/tf/grafana-db/aws.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  region              = "ap-northeast-1"
+  allowed_account_ids = ["005216166247"]
+
+  default_tags {
+    tags = {
+      Project   = "rk24net"
+      Component = "grafana"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}

--- a/tf/grafana-db/backend.tf
+++ b/tf/grafana-db/backend.tf
@@ -1,0 +1,17 @@
+terraform {
+  backend "s3" {
+    bucket         = "rk-infra"
+    region         = "ap-northeast-1"
+    key            = "terraform/nw-grafana-db.tfstate"
+    dynamodb_table = "rk-terraform"
+  }
+}
+
+data "terraform_remote_state" "k8s" {
+  backend = "s3"
+  config = {
+    bucket = "rk-infra"
+    region = "ap-northeast-1"
+    key    = "terraform/nw-k8s.tfstate"
+  }
+}

--- a/tf/grafana-db/rds.tf
+++ b/tf/grafana-db/rds.tf
@@ -1,0 +1,78 @@
+resource "aws_rds_cluster" "grafana" {
+  cluster_identifier = "grafana1"
+  engine             = "aurora-mysql"
+  engine_version     = "8.0.mysql_aurora.3.04.2"
+
+  database_name = "grafana"
+
+  master_username = "rk"
+  master_password = "himitsudayo"
+
+  db_subnet_group_name = "rk-private"
+
+  vpc_security_group_ids = [aws_security_group.grafana-db.id]
+
+  backup_retention_period = 2
+  preferred_backup_window = "12:00-14:00"
+
+  final_snapshot_identifier = "grafana-rk24-final"
+
+  apply_immediately = true
+}
+
+
+resource "aws_rds_cluster_instance" "grafana-001" {
+  identifier         = "grafana-001"
+  cluster_identifier = aws_rds_cluster.grafana.id
+  instance_class     = "db.t4g.medium"
+  engine             = aws_rds_cluster.grafana.engine
+  engine_version     = aws_rds_cluster.grafana.engine_version
+}
+
+resource "aws_security_group" "grafana-db" {
+  name        = "grafana-db"
+  description = "rubykaigi-nw tf/grafana"
+  vpc_id      = data.aws_vpc.main.id
+}
+
+resource "aws_security_group_rule" "grafana-db_k8s-node" {
+  security_group_id        = aws_security_group.grafana-db.id
+  type                     = "ingress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  source_security_group_id = data.terraform_remote_state.k8s.outputs.node_security_group
+}
+
+resource "aws_security_group_rule" "grafana-db_icmp" {
+  security_group_id = aws_security_group.grafana-db.id
+  type              = "ingress"
+  from_port         = -1
+  to_port           = -1
+  protocol          = "icmp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+}
+
+data "aws_security_group" "bastion" {
+  vpc_id = data.aws_vpc.main.id
+  name   = "bastion"
+}
+resource "aws_security_group_rule" "grafana-db_bastion" {
+  security_group_id        = aws_security_group.grafana-db.id
+  type                     = "ingress"
+  from_port                = 3306
+  to_port                  = 3306
+  protocol                 = "tcp"
+  source_security_group_id = data.aws_security_group.bastion.id
+}
+
+resource "aws_route53_record" "grafana1-db-apne1-rubykaigi-net" {
+  zone_id = data.aws_route53_zone.rubykaigi-net_private.id
+  name    = "grafana1.db.apne1.rubykaigi.net."
+  type    = "CNAME"
+  ttl     = 5
+  records = [
+    "${aws_rds_cluster.grafana.endpoint}.",
+  ]
+}

--- a/tf/grafana-db/route53.tf
+++ b/tf/grafana-db/route53.tf
@@ -1,0 +1,4 @@
+data "aws_route53_zone" "rubykaigi-net_private" {
+  name         = "rubykaigi.net."
+  private_zone = true
+}

--- a/tf/grafana-db/versions.tf
+++ b/tf/grafana-db/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/tf/grafana-db/vpc.tf
+++ b/tf/grafana-db/vpc.tf
@@ -1,0 +1,3 @@
+data "aws_vpc" "main" {
+  id = "vpc-004eca6fe0bf3494d"
+}

--- a/tf/grafana/.terraform.lock.hcl
+++ b/tf/grafana/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/grafana/grafana" {
+  version = "2.18.0"
+  hashes = [
+    "h1:Mt6Gkmoe5+mWcmU7flEpWhsU5KvRd9xkljb3l5KLGys=",
+    "zh:319b6d7f1afbc9023be2a714c40cec80f8fc4452a16c073baa5b1b4a3f53c494",
+    "zh:6191d8a393156e176c0916264a4dd3d2efec6079ea74ee0883ba636893e7b418",
+    "zh:841a4099a034eef60dbe2f6f9c3d87f7f8ffd73920de7000e4bf1aedeb92a4cf",
+    "zh:86ea06ca503b0f4d343c4f7b3d38fc12a6a6b7ebe285e3a2f17bc89ac82fbff9",
+    "zh:88950889abe765464b4ace7e977498636ecabcfaa97f961c7b0125a6989cce11",
+    "zh:93b4c29f4a904c8a7f787f13619012ebafd43bba171c623f4d18d9cdb6f3a9df",
+    "zh:9aa33527fc3da0b2edbfabd79a4dca021723efa44fd598733816584e229745e3",
+    "zh:9ba83d1ef37e14f849160dcdc91c62f9e6d9bd5b2babf287c59aea32b4bf4f0b",
+    "zh:aea1e56115ad302e382d5c38228c169c74655db27e09af0fea193b7dd8efb9b7",
+    "zh:c3f9e2123d9b2c930cf9e363efae3015222c23cd8d74aba1b588454a2183e252",
+    "zh:d3a61681092472dae44ff4e6318b2a0ed154d36839ee6b8910a5982c84dcaa5f",
+    "zh:e40a02a191a93eb25dfebc12144c198f3ebe8992333060740f749f8dacbe72bf",
+    "zh:f53b8a6f4d941033ba6ae490bb590b56730bef4a75ff1cdd8acf8d1cf622dd29",
+    "zh:fd69199e3b6a90e7bd98f53f8a5da20b78dfe258a474e018b9c615bbbcec9472",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.46.0"
   constraints = ">= 5.0.0"

--- a/tf/grafana/README.md
+++ b/tf/grafana/README.md
@@ -1,0 +1,1 @@
+Apply `tf/grafana-db` before this module (`tf/grafana`).

--- a/tf/grafana/README.md
+++ b/tf/grafana/README.md
@@ -1,1 +1,4 @@
-Apply `tf/grafana-db` before this module (`tf/grafana`).
+1. Apply `tf/grafana-db` (See also `tf/grafana-db/README.md`).
+2. Apply this module (`tf/grafana`).
+3. Update OIDC client id/secret in `tf/himari` and ask @sorah to apply the change.
+4. Log in to <https://grafana.rubykaigi.net> and rename the default organization to "RubyKaigi".

--- a/tf/grafana/grafana.jsonnet
+++ b/tf/grafana/grafana.jsonnet
@@ -33,4 +33,12 @@ function(args)
         org_role: 'Viewer',
       },
     },
+    extraSecretMounts: [
+      {
+        name: 'oidc-client',
+        mountPath: '/var/run/secrets/oidc-client',
+        secretName: 'grafana-oidc-client',
+        readOnly: true,
+      },
+    ],
   }

--- a/tf/grafana/grafana.jsonnet
+++ b/tf/grafana/grafana.jsonnet
@@ -1,16 +1,11 @@
 function(args)
   {
+    replicas: 2,
     resources: {
       requests: {
         cpu: '5m',
         memory: '64M',
       },
-    },
-    persistence: {
-      enabled: true,
-    },
-    deploymentStrategy: {
-      type: 'Recreate',  // For PVC
     },
     plugins: [
       'knightss27-weathermap-panel',
@@ -23,6 +18,13 @@ function(args)
     'grafana.ini': {
       server: {
         root_url: 'https://grafana.rubykaigi.net/',
+      },
+      database: {
+        type: 'mysql',
+        host: 'grafana1.db.apne1.rubykaigi.net',
+        name: 'grafana',
+        user: '$__file{/var/run/secrets/mysql/username}',
+        password: '$__file{/var/run/secrets/mysql/password}',
       },
       feature_toggles: {
         publicDashboards: true,
@@ -38,6 +40,12 @@ function(args)
         name: 'oidc-client',
         mountPath: '/var/run/secrets/oidc-client',
         secretName: 'grafana-oidc-client',
+        readOnly: true,
+      },
+      {
+        name: 'mysql',
+        mountPath: '/var/run/secrets/mysql',
+        secretName: 'grafana-mysql',
         readOnly: true,
       },
     ],

--- a/tf/grafana/grafana.tf
+++ b/tf/grafana/grafana.tf
@@ -20,6 +20,10 @@ resource "helm_release" "grafana" {
       },
     }),
   ]
+
+  depends_on = [
+    kubernetes_secret.grafana-admin,
+  ]
 }
 
 data "external" "grafana-values" {
@@ -32,6 +36,24 @@ data "external" "grafana-values" {
       role_private = aws_iam_role.grafana-private.arn,
     })
   }
+}
+
+resource "random_password" "grafana-admin" {
+  length  = 64
+  special = false
+}
+
+resource "kubernetes_secret" "grafana-admin" {
+  metadata {
+    name = "grafana-admin"
+  }
+
+  data = {
+    username = "admin"
+    password = random_password.grafana-admin.result
+  }
+
+  type = "kubernetes.io/basic-auth"
 }
 
 data "aws_lb_target_group" "common-grafana" {

--- a/tf/grafana/grafana.tf
+++ b/tf/grafana/grafana.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "grafana" {
   repository = "https://grafana.github.io/helm-charts"
   chart      = "grafana"
-  version    = "6.52.9"
+  version    = "7.3.9"
 
   name = "grafana"
 
@@ -23,6 +23,7 @@ resource "helm_release" "grafana" {
 
   depends_on = [
     kubernetes_secret.grafana-admin,
+    kubernetes_secret.oidc-client,
   ]
 }
 

--- a/tf/grafana/grafana_config.tf
+++ b/tf/grafana/grafana_config.tf
@@ -1,0 +1,61 @@
+provider "grafana" {
+  url  = "https://grafana.rubykaigi.net/"
+  auth = "admin:${random_password.grafana-admin.result}"
+}
+
+resource "grafana_organization" "rk-private" {
+  name       = "RubyKaigi (ひみつだよ)"
+  admin_user = "admin"
+}
+
+resource "grafana_data_source" "prometheus" {
+  type = "prometheus"
+  name = "Prometheus"
+  url  = "http://prometheus-operated.default.svc.cluster.local:9090"
+
+  is_default = true
+}
+
+resource "grafana_data_source" "alertmanager" {
+  type = "alertmanager"
+  name = "Alertmanager"
+  url  = "http://alertmanager-operated.default.svc.cluster.local:9093"
+
+  json_data_encoded = jsonencode({
+    implementation = "prometheus",
+  })
+}
+
+resource "grafana_data_source" "cloudwatch" {
+  type = "cloudwatch"
+  name = "cloudwatch"
+
+  json_data_encoded = jsonencode({
+    authType      = "default",
+    defaultRegion = "ap-northeast-1",
+    assumeRoleArn = aws_iam_role.grafana-public.arn,
+  })
+}
+
+resource "grafana_data_source" "prometheus-private" {
+  org_id = grafana_organization.rk-private.org_id
+
+  type = "prometheus"
+  name = "Prometheus"
+  url  = "http://prometheus-operated.default.svc.cluster.local:9090"
+
+  is_default = true
+}
+
+resource "grafana_data_source" "cloudwatch-private" {
+  org_id = grafana_organization.rk-private.org_id
+
+  type = "cloudwatch-private"
+  name = "cloudwatch"
+
+  json_data_encoded = jsonencode({
+    authType      = "default",
+    defaultRegion = "ap-northeast-1",
+    assumeRoleArn = aws_iam_role.grafana-private.arn,
+  })
+}

--- a/tf/grafana/oidc_client.tf
+++ b/tf/grafana/oidc_client.tf
@@ -10,8 +10,8 @@ locals {
     enabled              = true
     name                 = "RubyKaigi-StaffIdP"
     allow_sign_up        = true
-    client_id            = random_uuid.client_id.result
-    client_secret        = random_id.client_secret.id
+    client_id            = "$__file{/var/run/secrets/oidc-client/client_id}"
+    client_secret        = "$__file{/var/run/secrets/oidc-client/client_secret}"
     scopes               = "openid"
     email_attribute_path = "email"
     login_attribute_path = "sub"
@@ -22,6 +22,17 @@ locals {
 
     role_attribute_path        = "contains(roles[*], 'admin') && 'GrafanaAdmin' || contains(roles[*], 'editor') && 'Editor' || 'Viewer'"
     allow_assign_grafana_admin = true
+  }
+}
+
+resource "kubernetes_secret" "oidc-client" {
+  metadata {
+    name = "grafana-oidc-client"
+  }
+
+  data = {
+    client_id     = random_uuid.client_id.result
+    client_secret = random_id.client_secret.id
   }
 }
 

--- a/tf/grafana/versions.tf
+++ b/tf/grafana/versions.tf
@@ -16,6 +16,9 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
+    grafana = {
+      source = "grafana/grafana"
+    }
     random = {
       source = "hashicorp/random"
     }


### PR DESCRIPTION
- Helm chartのバージョンをあげた (Grafana v10.4.1)
- データベースをRDSに移した
  - PVCをつけてるとnode distruptionで断を避けられないので
  - MySQLの手動オペレーションがいるのでgrafana-dbはtfstateを分けた
- Grafana上の設定はgrafana terraform providerでいれるようにした