### PR TITLE
xlat: misc

### DIFF
--- a/itamae/cookbooks/iproute2/default.rb
+++ b/itamae/cookbooks/iproute2/default.rb
@@ -1,0 +1,5 @@
+template '/etc/iproute2/rt_tables' do
+  owner 'root'
+  group 'root'
+  mode  '0644'
+end

--- a/itamae/cookbooks/iproute2/templates/etc/iproute2/rt_tables
+++ b/itamae/cookbooks/iproute2/templates/etc/iproute2/rt_tables
@@ -1,0 +1,12 @@
+#
+# reserved values
+#
+255     local
+254     main
+253     default
+0       unspec
+#
+# local
+#
+64  tun-siit
+200 mgmt

--- a/itamae/cookbooks/systemd-networkd/default.rb
+++ b/itamae/cookbooks/systemd-networkd/default.rb
@@ -51,6 +51,14 @@ else
   end
 end
 
+file '/etc/systemd/networkd.conf.d/99-speedmeter.conf' do
+  content "[Network]\nSpeedMeter=yes\nSpeedMeterIntervalSec=10\n"
+  owner 'root'
+  group 'root'
+  mode '0644'
+end
+
+
 package 'systemd-resolved' do
   action :install
 end

--- a/itamae/hosts.yml
+++ b/itamae/hosts.yml
@@ -5,10 +5,16 @@ nat-69.tkyk.rubykaigi.net:
     run_list:
       - hosts/nat-69.tkyk.rubykaigi.net/default.rb
 
-
 nat-61.venue.rubykaigi.net:
   ssh_options:
     host_name: me0.nat-61.venue.rubykaigi.net
   properties:
     run_list:
       - hosts/nat-61.venue.rubykaigi.net/default.rb
+
+nat-62.venue.rubykaigi.net:
+  ssh_options:
+    host_name: me0.nat-62.venue.rubykaigi.net
+  properties:
+    run_list:
+      - hosts/nat-62.venue.rubykaigi.net/default.rb

--- a/itamae/hosts.yml
+++ b/itamae/hosts.yml
@@ -4,3 +4,11 @@ nat-69.tkyk.rubykaigi.net:
   properties:
     run_list:
       - hosts/nat-69.tkyk.rubykaigi.net/default.rb
+
+
+nat-61.venue.rubykaigi.net:
+  ssh_options:
+    host_name: me0.nat-61.venue.rubykaigi.net
+  properties:
+    run_list:
+      - hosts/nat-61.venue.rubykaigi.net/default.rb

--- a/itamae/hosts/nat-61.venue.rubykaigi.net/default.rb
+++ b/itamae/hosts/nat-61.venue.rubykaigi.net/default.rb
@@ -1,0 +1,50 @@
+node.reverse_merge!(
+  systemd_networkd: {
+    migrate_netplan: false,
+  },
+  plat: {
+    nat64: {
+      outer_public: '192.50.220.162',
+      outer_private: '10.33.40.162',
+    },
+    interfaces: {
+      loopback: {
+        address4: %w[10.33.0.23],
+        address6: %w[2001:df0:8500:ca00::23],
+      },
+      management: {
+        name: 'me0',
+        path: '*-usb-0:2:1.0',
+        duid: '00:00:ba:2c:33:00:23',
+      },
+      outside: {
+        name: 'enp1s0',
+        local_as: 65026,
+        peer_as: 65010,
+        link4: {
+          peer: '10.33.22.48',
+          local: '10.33.22.49',
+        },
+        link6: {
+          peer: '2001:df0:8500:ca22:48::a',
+          local: '2001:df0:8500:ca22:48::b',
+        },
+      },
+      inside: {
+        name: 'enp2s0',
+        local_as: 65026,
+        peer_as: 65030,
+        link4: {
+          local: '10.33.22.64',
+          peer: '10.33.22.65',
+        },
+        link6: {
+          local: '2001:df0:8500:ca22:64::a',
+          peer: '2001:df0:8500:ca22:64::b',
+        },
+      },
+    },
+  }
+)
+
+include_role 'plat'

--- a/itamae/hosts/nat-62.venue.rubykaigi.net/default.rb
+++ b/itamae/hosts/nat-62.venue.rubykaigi.net/default.rb
@@ -1,0 +1,50 @@
+node.reverse_merge!(
+  systemd_networkd: {
+    migrate_netplan: false,
+  },
+  plat: {
+    nat64: {
+      outer_public: '192.50.220.163',
+      outer_private: '10.33.40.163',
+    },
+    interfaces: {
+      loopback: {
+        address4: %w[10.33.0.24],
+        address6: %w[2001:df0:8500:ca00::24],
+      },
+      management: {
+        name: 'me0',
+        path: '*-usb-0:2:1.0',
+        duid: '00:00:ba:2c:33:00:23',
+      },
+      outside: {
+        name: 'enp1s0',
+        local_as: 65026,
+        peer_as: 65010,
+        link4: {
+          peer: '10.33.22.50',
+          local: '10.33.22.51',
+        },
+        link6: {
+          peer: '2001:df0:8500:ca22:50::a',
+          local: '2001:df0:8500:ca22:50::b',
+        },
+      },
+      inside: {
+        name: 'enp2s0',
+        local_as: 65026,
+        peer_as: 65030,
+        link4: {
+          local: '10.33.22.66',
+          peer: '10.33.22.67',
+        },
+        link6: {
+          local: '2001:df0:8500:ca22:66::a',
+          peer: '2001:df0:8500:ca22:67::b',
+        },
+      },
+    },
+  }
+)
+
+include_role 'plat'

--- a/itamae/roles/base/default.rb
+++ b/itamae/roles/base/default.rb
@@ -6,3 +6,4 @@ node.reverse_merge!(
 )
 
 include_cookbook 'systemd-networkd'
+include_cookbook 'iproute2'

--- a/itamae/roles/plat/default.rb
+++ b/itamae/roles/plat/default.rb
@@ -31,6 +31,20 @@ package 'conntrack'
   end
 end
 
+if node.dig(:plat, :interfaces, :management)
+  %w[
+    00-management.network
+    00-management.link
+  ].each do |fname|
+    template "/etc/systemd/network/#{fname}" do
+      owner 'root'
+      group 'root'
+      mode '0644'
+      notifies :restart, 'service[systemd-networkd]'
+    end
+  end
+end
+
 template '/etc/nftables/plat.conf' do
   owner 'root'
   group 'root'

--- a/itamae/roles/plat/templates/etc/bird/bird.conf.d/plat.conf
+++ b/itamae/roles/plat/templates/etc/bird/bird.conf.d/plat.conf
@@ -1,3 +1,4 @@
+# vim: set ft=bird nofoldenable:
 ipv4 table static4;
 ipv6 table static6;
 ipv4 table bgp4;
@@ -61,6 +62,7 @@ protocol static {
   };
 
   route 2001:df0:8500:ca6d::/64 blackhole;
+  route 2001:df0:8500:ca64::/64 blackhole;
   route 2001:df0:8500:ca64:a9:8200::/96 via "tun-siit";
 }
 
@@ -129,7 +131,7 @@ protocol bgp bgp_inside {
       if net ~ [2001:df0:8500:ca00::/56+] then accept;
     };
     export filter {
-      if net ~ [2001:df0:8500:ca00::/56+] then accept;
+      if net ~ [2001:df0:8500:ca00::/56{56,64}] then accept;
     };
   };
 }

--- a/itamae/roles/plat/templates/etc/nftables/plat.conf
+++ b/itamae/roles/plat/templates/etc/nftables/plat.conf
@@ -1,3 +1,4 @@
+# vim: ft=nftables
 <%-
 def embed_v4(prefix, addr)
   prefix.sub('::/96', sprintf(':%02x%02x:%02x%02x', *addr.split(?.).map(&:to_i))) or fail 'prefix is not /96'
@@ -9,7 +10,6 @@ outer_private = nat64.fetch(:outer_private)
 
 pref64n = '2001:df0:8500:ca64:a9:8200::/96'
 internal = '2001:df0:8500:ca61:ac:8200::/96'
-
 -%>
 
 define pref64n = 2001:df0:8500:ca64:a9:8200::/96

--- a/itamae/roles/plat/templates/etc/systemd/network/00-inside.network
+++ b/itamae/roles/plat/templates/etc/systemd/network/00-inside.network
@@ -6,6 +6,8 @@ Name=<%= iface.fetch(:name) %>
 
 [Network]
 IPForward=yes
+LLDP=yes
+EmitLLDP=yes
 <%- unless node.dig(:plat, :interfaces, :management) -%>
 Gateway=<%= link4.fetch(:peer) %>
 Gateway=<%= link6.fetch(:peer) %>

--- a/itamae/roles/plat/templates/etc/systemd/network/00-inside.network
+++ b/itamae/roles/plat/templates/etc/systemd/network/00-inside.network
@@ -6,8 +6,10 @@ Name=<%= iface.fetch(:name) %>
 
 [Network]
 IPForward=yes
+<%- unless node.dig(:plat, :interfaces, :management) -%>
 Gateway=<%= link4.fetch(:peer) %>
 Gateway=<%= link6.fetch(:peer) %>
+<%- end -%>
 
 [Address]
 Address=<%= link4.fetch(:local) %>/32

--- a/itamae/roles/plat/templates/etc/systemd/network/00-management.link
+++ b/itamae/roles/plat/templates/etc/systemd/network/00-management.link
@@ -1,0 +1,7 @@
+<%- iface = node.dig(:plat, :interfaces, :management) -%>
+[Match]
+Path=<%= iface.fetch(:path) %>
+
+[Link]
+Name=<%= iface.fetch(:name) %>
+AlternativeNamesPolicy=mac

--- a/itamae/roles/plat/templates/etc/systemd/network/00-management.network
+++ b/itamae/roles/plat/templates/etc/systemd/network/00-management.network
@@ -1,0 +1,24 @@
+<%- iface = node.dig(:plat, :interfaces, :management) -%>
+[Match]
+Name=<%= iface.fetch(:name) %>
+
+[Network]
+IPForward=no
+IPv6AcceptRA=yes
+DHCP=ipv4
+LLDP=yes
+EmitLLDP=yes
+LinkLocalAddressing=yes
+
+[DHCPv4]
+SendHostname=yes
+UseDNS=yes
+UseMTU=yes
+ClientIdentifier=duid
+DUIDType=vendor
+DUIDRawData=<%= iface.fetch(:duid) %>
+
+
+[IPv6AcceptRA]
+UseDNS=yes
+UseMTU=yes

--- a/itamae/roles/plat/templates/etc/systemd/network/00-outside.network
+++ b/itamae/roles/plat/templates/etc/systemd/network/00-outside.network
@@ -6,6 +6,8 @@ Name=<%= iface.fetch(:name) %>
 
 [Network]
 IPForward=yes
+LLDP=yes
+EmitLLDP=yes
 
 [Address]
 Address=<%= link4.fetch(:local) %>/32


### PR DESCRIPTION
to #153 

- RAを吐くための別ポートが必要 (routed port にしてるので別に family ethernet-switching のための線が必要)
  - ついでに mgmt への足を持たせた
- pref64n, Junos の RIB/FIB には /64 で経路を持たせる
- LLDP