### PR TITLE
plat: SNAT pref64n::192.50.220.16[45] to private address

### DIFF
--- a/itamae/roles/plat/templates/etc/nftables/plat.conf
+++ b/itamae/roles/plat/templates/etc/nftables/plat.conf
@@ -7,6 +7,7 @@ end
 nat64 = node.dig(:plat, :nat64)
 outer_public = nat64.fetch(:outer_public)
 outer_private = nat64.fetch(:outer_private)
+resolver4 = %w[192.50.220.164 192.50.220.165]
 
 pref64n = '2001:df0:8500:ca64:a9:8200::/96'
 internal = '2001:df0:8500:ca61:ac:8200::/96'
@@ -14,7 +15,7 @@ internal = '2001:df0:8500:ca61:ac:8200::/96'
 
 define pref64n = 2001:df0:8500:ca64:a9:8200::/96
 define nat64_outer = { <%= outer_public %>, <%= outer_private %> }
-define dnat_mark = 53
+define private_snat_mark = 53
 
 table inet plat {
   ct timeout udp-oneshot {
@@ -31,8 +32,9 @@ table inet plat {
 
   chain dstnat {
     type nat hook prerouting priority dstnat;
-    ip6 daddr 2001:df0:8500:ca6d:53::c ct mark set $dnat_mark counter dnat ip6 to <%= embed_v4(pref64n, '192.50.220.164') %>
-    ip6 daddr 2001:df0:8500:ca6d:53::d ct mark set $dnat_mark counter dnat ip6 to <%= embed_v4(pref64n, '192.50.220.165') %>
+    ip6 daddr 2001:df0:8500:ca6d:53::c ct mark set $private_snat_mark counter dnat ip6 to <%= embed_v4(pref64n, '192.50.220.164') %>
+    ip6 daddr 2001:df0:8500:ca6d:53::d ct mark set $private_snat_mark counter dnat ip6 to <%= embed_v4(pref64n, '192.50.220.165') %>
+    ip6 daddr { <%= resolver4.map {|_| embed_v4(pref64n, _) }.join(', ') %> } ct mark set $private_snat_mark return
   }
 
   chain input {
@@ -79,8 +81,8 @@ table inet plat {
 
   chain srcnat {
     type nat hook postrouting priority srcnat;
-    ip6 daddr $pref64n ct mark $dnat_mark meta l4proto {tcp, udp} counter snat ip6 to <%= embed_v4(internal, outer_private) %>:1024-65535
-    ip6 daddr $pref64n ct mark $dnat_mark counter snat ip6 to <%= embed_v4(internal, outer_private) %>
+    ip6 daddr $pref64n ct mark $private_snat_mark meta l4proto {tcp, udp} counter snat ip6 to <%= embed_v4(internal, outer_private) %>:1024-65535
+    ip6 daddr $pref64n ct mark $private_snat_mark counter snat ip6 to <%= embed_v4(internal, outer_private) %>
     ip6 daddr $pref64n meta l4proto {tcp, udp} counter snat ip6 to <%= embed_v4(internal, outer_public) %>:1024-65535
     ip6 daddr $pref64n counter snat ip6 to <%= embed_v4(internal, outer_public) %>
   }


### PR DESCRIPTION
The resolver expects DNS queries to have private source address. Otherwise, the responses cannot return to the onpremises.