### PR TITLE
plat: use private SNAT outer address for private traffic

### DIFF
--- a/itamae/roles/plat/templates/etc/nftables/plat.conf
+++ b/itamae/roles/plat/templates/etc/nftables/plat.conf
@@ -78,6 +78,7 @@ table inet plat {
 
   chain forward-xlat {
     meta l4proto tcp ct state invalid,untracked counter reject with tcp reset
+    ct state invalid,untracked counter drop
     accept
   }
 

--- a/itamae/roles/plat/templates/etc/nftables/plat.conf
+++ b/itamae/roles/plat/templates/etc/nftables/plat.conf
@@ -1,13 +1,16 @@
 # vim: ft=nftables
 <%-
-def embed_v4(prefix, addr)
-  prefix.sub('::/96', sprintf(':%02x%02x:%02x%02x', *addr.split(?.).map(&:to_i))) or fail 'prefix is not /96'
+def embed_v4(v6prefix, v4)
+  v4addr, v4prefixlen = v4.split(?/, 2)
+  v6prefixlen = v4prefixlen.to_i + 96 if v4prefixlen
+
+  v6prefix.sub('::/96', [sprintf(':%02x%02x:%02x%02x', *v4.split(?.).map(&:to_i)), *v6prefixlen].join(?/)) or fail 'v6prefix is not /96'
 end
 
 nat64 = node.dig(:plat, :nat64)
 outer_public = nat64.fetch(:outer_public)
 outer_private = nat64.fetch(:outer_private)
-resolver4 = %w[192.50.220.164 192.50.220.165]
+private_snat_dest = %w[10.33.0.0/16 192.50.220.164/31]
 
 pref64n = '2001:df0:8500:ca64:a9:8200::/96'
 internal = '2001:df0:8500:ca61:ac:8200::/96'
@@ -15,7 +18,7 @@ internal = '2001:df0:8500:ca61:ac:8200::/96'
 
 define pref64n = 2001:df0:8500:ca64:a9:8200::/96
 define nat64_outer = { <%= outer_public %>, <%= outer_private %> }
-define private_snat_mark = 53
+define private_snat_dest = { <%= private_snat_dest.map {|_| embed_v4(pref64n, _) }.join(', ') %> }
 
 table inet plat {
   ct timeout udp-oneshot {
@@ -32,9 +35,8 @@ table inet plat {
 
   chain dstnat {
     type nat hook prerouting priority dstnat;
-    ip6 daddr 2001:df0:8500:ca6d:53::c ct mark set $private_snat_mark counter dnat ip6 to <%= embed_v4(pref64n, '192.50.220.164') %>
-    ip6 daddr 2001:df0:8500:ca6d:53::d ct mark set $private_snat_mark counter dnat ip6 to <%= embed_v4(pref64n, '192.50.220.165') %>
-    ip6 daddr { <%= resolver4.map {|_| embed_v4(pref64n, _) }.join(', ') %> } ct mark set $private_snat_mark return
+    ip6 daddr 2001:df0:8500:ca6d:53::c counter dnat ip6 to <%= embed_v4(pref64n, '192.50.220.164') %>
+    ip6 daddr 2001:df0:8500:ca6d:53::d counter dnat ip6 to <%= embed_v4(pref64n, '192.50.220.165') %>
   }
 
   chain input {
@@ -81,8 +83,8 @@ table inet plat {
 
   chain srcnat {
     type nat hook postrouting priority srcnat;
-    ip6 daddr $pref64n ct mark $private_snat_mark meta l4proto {tcp, udp} counter snat ip6 to <%= embed_v4(internal, outer_private) %>:1024-65535
-    ip6 daddr $pref64n ct mark $private_snat_mark counter snat ip6 to <%= embed_v4(internal, outer_private) %>
+    ip6 daddr $private_snat_dest meta l4proto {tcp, udp} counter snat ip6 to <%= embed_v4(internal, outer_private) %>:1024-65535
+    ip6 daddr $private_snat_dest counter snat ip6 to <%= embed_v4(internal, outer_private) %>
     ip6 daddr $pref64n meta l4proto {tcp, udp} counter snat ip6 to <%= embed_v4(internal, outer_public) %>:1024-65535
     ip6 daddr $pref64n counter snat ip6 to <%= embed_v4(internal, outer_public) %>
   }


### PR DESCRIPTION
整理した結果，outerアドレスは（DNAT後の）宛先アドレスだけ見て決めればよくて，CT markを使う必要なんてなかった