### PR TITLE
plat: Reject untracked ingress flow

### DIFF
--- a/itamae/roles/plat/templates/etc/nftables/plat.conf
+++ b/itamae/roles/plat/templates/etc/nftables/plat.conf
@@ -81,6 +81,7 @@ table inet plat {
     iifname "tun-siit" oif $if_inside counter goto forward-xlat2inside
     iif $if_inside oifname "tun-siit" counter goto forward-inside2xlat
     iifname "tun-siit" oif $if_outside counter goto forward-xlat2outside
+    iifname "tun-siit" oifname "tun-siit" counter goto forward-xlat2xlat
 
     counter
   }
@@ -107,6 +108,11 @@ table inet plat {
 
   chain forward-xlat2outside {
     ip saddr $nat64_outer accept
+    counter drop
+  }
+
+  chain forward-xlat2xlat {
+    meta nfproto ipv4 accept
     counter drop
   }
 }

--- a/itamae/roles/plat/templates/etc/nftables/plat.conf
+++ b/itamae/roles/plat/templates/etc/nftables/plat.conf
@@ -15,15 +15,21 @@ private_snat_dest = %w[10.33.0.0/16 192.50.220.164/31]
 pref64n = '2001:df0:8500:ca64:a9:8200::/96'
 internal = '2001:df0:8500:ca61:ac:8200::/96'
 -%>
-
 define pref64n = 2001:df0:8500:ca64:a9:8200::/96
 define nat64_outer = { <%= outer_public %>, <%= outer_private %> }
 define private_snat_dest = { <%= private_snat_dest.map {|_| embed_v4(pref64n, _) }.join(', ') %> }
+
+define if_outside = "<%= node.dig(:plat, :interfaces, :outside).fetch(:name) %>"
+define if_inside = "<%= node.dig(:plat, :interfaces, :inside).fetch(:name) %>"
 
 table inet plat {
   ct timeout udp-oneshot {
     protocol udp;
     policy = { unreplied: 10s, replied: 0s };
+  }
+
+  chain ct-timeout {
+    udp dport { domain, ntp } ct timeout set "udp-oneshot" return
   }
 
   chain prerouting {
@@ -37,6 +43,14 @@ table inet plat {
     type nat hook prerouting priority dstnat;
     ip6 daddr 2001:df0:8500:ca6d:53::c counter dnat ip6 to <%= embed_v4(pref64n, '192.50.220.164') %>
     ip6 daddr 2001:df0:8500:ca6d:53::d counter dnat ip6 to <%= embed_v4(pref64n, '192.50.220.165') %>
+  }
+
+  chain srcnat {
+    type nat hook postrouting priority srcnat;
+    ip6 daddr $private_snat_dest meta l4proto {tcp, udp} counter snat ip6 to <%= embed_v4(internal, outer_private) %>:1024-65535
+    ip6 daddr $private_snat_dest counter snat ip6 to <%= embed_v4(internal, outer_private) %>
+    ip6 daddr $pref64n meta l4proto {tcp, udp} counter snat ip6 to <%= embed_v4(internal, outer_public) %>:1024-65535
+    ip6 daddr $pref64n counter snat ip6 to <%= embed_v4(internal, outer_public) %>
   }
 
   chain input {
@@ -63,30 +77,36 @@ table inet plat {
 
     jump ct-timeout
 
-    iifname "tun-siit" accept
-
-    ip daddr $nat64_outer counter accept
-    ip6 saddr 2001:df0:8500:ca00::/56 ip6 daddr 2001:df0:8500:ca6d::/64 counter goto forward-xlat
-    ip6 saddr 2001:df0:8500:ca00::/56 ip6 daddr $pref64n counter goto forward-xlat
+    iif $if_outside oifname "tun-siit" counter goto forward-outside2xlat
+    iifname "tun-siit" oif $if_inside counter goto forward-xlat2inside
+    iif $if_inside oifname "tun-siit" counter goto forward-inside2xlat
+    iifname "tun-siit" oif $if_outside counter goto forward-xlat2outside
 
     counter
   }
 
-  chain ct-timeout {
-    udp dport { domain, ntp } ct timeout set "udp-oneshot" return
+  chain forward-outside2xlat {
+    ip daddr $nat64_outer accept
+    counter drop
   }
 
-  chain forward-xlat {
+  chain forward-xlat2inside {
+    ct state invalid,new,untracked counter counter drop
+
+    ip6 saddr { $pref64n, 2001:df0:8500:ca6d::/64 } counter accept
+    counter drop
+  }
+
+  chain forward-inside2xlat {
     meta l4proto tcp ct state invalid,untracked counter reject with tcp reset
     ct state invalid,untracked counter drop
-    accept
+
+    ip6 saddr 2001:df0:8500:ca00::/56 ip6 daddr { $pref64n, 2001:df0:8500:ca6d::/64 } counter accept
+    counter drop
   }
 
-  chain srcnat {
-    type nat hook postrouting priority srcnat;
-    ip6 daddr $private_snat_dest meta l4proto {tcp, udp} counter snat ip6 to <%= embed_v4(internal, outer_private) %>:1024-65535
-    ip6 daddr $private_snat_dest counter snat ip6 to <%= embed_v4(internal, outer_private) %>
-    ip6 daddr $pref64n meta l4proto {tcp, udp} counter snat ip6 to <%= embed_v4(internal, outer_public) %>:1024-65535
-    ip6 daddr $pref64n counter snat ip6 to <%= embed_v4(internal, outer_public) %>
+  chain forward-xlat2outside {
+    ip saddr $nat64_outer accept
+    counter drop
   }
 }


### PR DESCRIPTION
Closes: #190 UDPのホールパンチングが安定して動くようにする

RubyKaigiのNAPT内のHost AのPort Nから，インターネットの向こうのHost BのPort Mとコネクションをはるとき，STUNサーバ $S:L$ を使って，

1. $A:N$ ($P_A:P_N$) -> $S:L$
2. $A:N$ ($P_A:P_N$) -> $B:M$
3. $A:N$ ($P_A:P_N$) <- $B:M$

とパケットを送る（カッコ内はNAPTされた外側アドレス）．

netfilterはポート競合がない場合EIMなので，1.と2.で外側アドレスはおなじになる．
2.のパケットが送られたときに，original: $A:N$ -> $B:M$, reply: $B:M$ -> $P_A:P_N$のconntrackエントリが作られるので，3のパケットをreplyパケットと認識して$A:N$に届けられる

---

1. $A:N$ ($P_A:P_N$) -> $S:L$
2. $P_A:P_N$ <- $B:M$
3. $A:N$ ($P_A:P'_N$) -> $B:M$

一方でBからのパケットがBにパケットを送るより先に届いた場合，original: $B:M$ -> $P_A:P_N$, reply: $P_A:P_N$ -> $B:M$と内向きのエントリが作られる．
その後AからBへパケットを送ると，すでにあるエントリとポートが競合しているので別の $P'_N$が選ばれて original: $A:N$ -> $B:M$, reply: $B:M$ -> $P_A:\underline{P'_N}$ となる．
BからみるとシグナリングサーバからもらったAのポート番号と異なるのでコネクション確立できない．

ここで2のパケット（つまり内向きでctstate newのパケット）をdropしてやると余分なconntrackエントリが作られなくなるので，うまく動く

---

という話だと理解をした

ref:
- https://turgenev.hatenablog.com/entry/2024/03/03/171152#:~:text=%E4%BE%8B2%3A%20%E5%A4%96%E9%83%A8%E3%81%8B%E3%82%89%E3%81%AE%E3%83%91%E3%82%B1%E3%83%83%E3%83%88%E3%81%AB%E3%82%88%E3%82%8B%E3%83%9E%E3%83%83%E3%83%94%E3%83%B3%E3%82%B0%E3%81%A8%E3%81%AE%E8%A1%9D%E7%AA%81