### PR TITLE
plat: respect routes from outside interface

### DIFF
--- a/itamae/roles/plat/templates/etc/bird/bird.conf.d/plat.conf
+++ b/itamae/roles/plat/templates/etc/bird/bird.conf.d/plat.conf
@@ -14,6 +14,7 @@ protocol direct {
   ipv6 {
     table bgp6;
   };
+  interface "-me0", "<%= node.dig(:plat, :interfaces).fetch(:outside).fetch(:name) %>", "<%= node.dig(:plat, :interfaces).fetch(:inside).fetch(:name) %>", "lo";
 }
 
 protocol kernel kernel_bgp4 {

--- a/itamae/roles/plat/templates/etc/bird/bird.conf.d/plat.conf
+++ b/itamae/roles/plat/templates/etc/bird/bird.conf.d/plat.conf
@@ -143,10 +143,7 @@ protocol bgp bgp_outside {
 
   ipv4 {
     table bgp4;
-    import filter {
-      if net = 0.0.0.0/0 then accept;
-      reject;
-    };
+    import all;
     export filter {
       if dest = RTD_UNREACHABLE then reject; # static recursive route can be RTD_UNREACHABLE when unresolvable
       if net = <%= node.dig(:plat, :nat64).fetch(:outer_public) %>/32 then accept;
@@ -156,7 +153,7 @@ protocol bgp bgp_outside {
   };
   ipv6 {
     table bgp6;
-    import none;
+    import all;
     export none;
   };
 }
@@ -170,7 +167,7 @@ protocol bgp bgp_inside {
   ipv4 {
     table bgp4;
     import filter {
-      if net ~ [10.33.0.0/16+] then accept;
+      if bgp_path ~ [= * <%= inside.fetch(:peer_as) %> =] then accept; # accept only direct path
       reject;
     };
     export filter {
@@ -182,7 +179,8 @@ protocol bgp bgp_inside {
   ipv6 {
     table bgp6;
     import filter {
-      if net ~ [2001:df0:8500:ca00::/56+] then accept;
+      if bgp_path ~ [= * <%= inside.fetch(:peer_as) %> =] then accept; # accept only direct path
+      reject;
     };
     export filter {
       if dest = RTD_UNREACHABLE then reject; # static recursive route can be RTD_UNREACHABLE when unresolvable

--- a/itamae/roles/plat/templates/etc/bird/bird.conf.d/plat.conf
+++ b/itamae/roles/plat/templates/etc/bird/bird.conf.d/plat.conf
@@ -146,6 +146,7 @@ protocol bgp bgp_outside {
     import all;
     export filter {
       if dest = RTD_UNREACHABLE then reject; # static recursive route can be RTD_UNREACHABLE when unresolvable
+      if proto = "direct1" then accept;
       if net = <%= node.dig(:plat, :nat64).fetch(:outer_public) %>/32 then accept;
       if net = <%= node.dig(:plat, :nat64).fetch(:outer_private) %>/32 then accept;
       reject;
@@ -154,7 +155,11 @@ protocol bgp bgp_outside {
   ipv6 {
     table bgp6;
     import all;
-    export none;
+    export filter {
+      if dest = RTD_UNREACHABLE then reject; # static recursive route can be RTD_UNREACHABLE when unresolvable
+      if proto = "direct1" then accept;
+      reject;
+    };
   };
 }
 
@@ -172,7 +177,10 @@ protocol bgp bgp_inside {
     };
     export filter {
       if dest = RTD_UNREACHABLE then reject; # static recursive route can be RTD_UNREACHABLE when unresolvable
-      if net ~ [10.33.0.0/16+] then accept;
+      if proto = "direct1" then accept;
+      if net !~ [10.33.0.0/16+] then reject;
+      if proto = "static1" then accept;
+      if proto = "static_bgp4" then accept;
       reject;
     };
   };
@@ -184,7 +192,10 @@ protocol bgp bgp_inside {
     };
     export filter {
       if dest = RTD_UNREACHABLE then reject; # static recursive route can be RTD_UNREACHABLE when unresolvable
-      if net ~ [2001:df0:8500:ca00::/56{56,64}] then accept;
+      if proto = "direct1" then accept;
+      if net !~ [2001:df0:8500:ca00::/56{56,64}] then reject;
+      if proto = "static1" then accept;
+      if proto = "static_bgp6" then accept;
     };
   };
 }


### PR DESCRIPTION
Supersedes #194 

- Designate inside interface for downstream, NAT'd traffic
- Move private traffic (10.33/16) to outside interface
- Add export filter to export loopback addresses to outside