### PR TITLE
plat: explicit static route filter using community

### DIFF
--- a/itamae/roles/plat/templates/etc/bird/bird.conf.d/plat.conf
+++ b/itamae/roles/plat/templates/etc/bird/bird.conf.d/plat.conf
@@ -7,6 +7,15 @@ ipv6 table bgp6;
 ipv4 table kernel_tun_siit4;
 ipv6 table kernel_tun_siit6;
 
+define C_SELF = 65026;
+define C_CTL_PREVENT_KERNEL = 10006;
+define C_CTL_ALLOW_OUTSIDE = 10011;
+define C_CTL_ALLOW_INSIDE = 10012;
+
+function filter_bgp_community() {
+  bgp_community.delete([(C_SELF, 10000..29999)]);
+}
+
 protocol direct {
   ipv4 {
     table bgp4;
@@ -57,8 +66,12 @@ protocol static {
     table static4;
   };
 
-  route <%= node.dig(:plat, :nat64).fetch(:outer_private) %>/32 via "tun-siit";
-  route <%= node.dig(:plat, :nat64).fetch(:outer_public) %>/32 via "tun-siit";
+  route <%= node.dig(:plat, :nat64).fetch(:outer_private) %>/32 via "tun-siit" {
+    bgp_community.add((C_SELF,C_CTL_ALLOW_OUTSIDE));
+  };
+  route <%= node.dig(:plat, :nat64).fetch(:outer_public) %>/32 via "tun-siit" {
+    bgp_community.add((C_SELF,C_CTL_ALLOW_OUTSIDE));
+  };
 }
 # protocol static static_bgp4 {
 #   ipv4 {
@@ -91,10 +104,12 @@ protocol static static_bgp6 {
   igp table bgp6;
   # Prevent propagation to always have blackhole route for pref64n and related prefixes in kernel tun-siit table
   route 2001:df0:8500:ca6d::/64 recursive 192.0.0.0 {
-    bgp_community.add((65026,6));
+    bgp_community.add((C_SELF,C_CTL_ALLOW_INSIDE));
+    bgp_community.add((C_SELF,C_CTL_PREVENT_KERNEL));
   };
   route 2001:df0:8500:ca64::/64 recursive 192.0.0.0 {
-    bgp_community.add((65026,6));
+    bgp_community.add((C_SELF,C_CTL_ALLOW_INSIDE));
+    bgp_community.add((C_SELF,C_CTL_PREVENT_KERNEL));
   };
 }
 # protocol pipe static2bgp6 {
@@ -106,7 +121,7 @@ protocol static static_bgp6 {
 
 
 filter prevent_kernel_installation {
-  if (defined(bgp_community)) then if ((65026,6) ~ bgp_community) then  reject;
+  if (defined(bgp_community)) then if ((C_SELF,C_CTL_PREVENT_KERNEL) ~ bgp_community) then  reject;
   accept;
 }
 
@@ -143,20 +158,26 @@ protocol bgp bgp_outside {
 
   ipv4 {
     table bgp4;
-    import all;
+    import filter {
+      filter_bgp_community();
+      accept;
+    };
     export filter {
       if dest = RTD_UNREACHABLE then reject; # static recursive route can be RTD_UNREACHABLE when unresolvable
+      if (defined(bgp_community)) then if ((C_SELF,C_CTL_ALLOW_OUTSIDE) ~ bgp_community) then accept; 
       if proto = "direct1" then accept;
-      if net = <%= node.dig(:plat, :nat64).fetch(:outer_public) %>/32 then accept;
-      if net = <%= node.dig(:plat, :nat64).fetch(:outer_private) %>/32 then accept;
       reject;
     };
   };
   ipv6 {
     table bgp6;
-    import all;
+    import filter {
+      filter_bgp_community();
+      accept;
+    };
     export filter {
       if dest = RTD_UNREACHABLE then reject; # static recursive route can be RTD_UNREACHABLE when unresolvable
+      if (defined(bgp_community)) then if ((C_SELF,C_CTL_ALLOW_OUTSIDE) ~ bgp_community) then accept;
       if proto = "direct1" then accept;
       reject;
     };
@@ -172,30 +193,28 @@ protocol bgp bgp_inside {
   ipv4 {
     table bgp4;
     import filter {
+      filter_bgp_community();
       if bgp_path ~ [= * <%= inside.fetch(:peer_as) %> =] then accept; # accept only direct path
       reject;
     };
     export filter {
       if dest = RTD_UNREACHABLE then reject; # static recursive route can be RTD_UNREACHABLE when unresolvable
+      if (defined(bgp_community)) then if ((C_SELF,C_CTL_ALLOW_INSIDE) ~ bgp_community) then accept;
       if proto = "direct1" then accept;
-      if net !~ [10.33.0.0/16+] then reject;
-      if proto = "static1" then accept;
-      if proto = "static_bgp4" then accept;
       reject;
     };
   };
   ipv6 {
     table bgp6;
     import filter {
+      filter_bgp_community();
       if bgp_path ~ [= * <%= inside.fetch(:peer_as) %> =] then accept; # accept only direct path
       reject;
     };
     export filter {
       if dest = RTD_UNREACHABLE then reject; # static recursive route can be RTD_UNREACHABLE when unresolvable
+      if (defined(bgp_community)) then if ((C_SELF,C_CTL_ALLOW_INSIDE) ~ bgp_community) then accept;
       if proto = "direct1" then accept;
-      if net !~ [2001:df0:8500:ca00::/56{56,64}] then reject;
-      if proto = "static1" then accept;
-      if proto = "static_bgp6" then accept;
     };
   };
 }


### PR DESCRIPTION
protocol "static1" contains /32 NAT outer address routes and the routes announced to inside peers; packets destined to such addresses is not accepted at $if_inside.

This patch allows to configure explicit intent for bgp announcement target on static routes for maintainability.

follow-up: https://github.com/ruby-no-kai/rubykaigi-net/pull/195