### PR TITLE
tf/dot-net(day): Correctly update Today's day number on change

### DIFF
--- a/tf/dot-net/day.html
+++ b/tf/dot-net/day.html
@@ -241,10 +241,9 @@
       }
 
       function updateTodayRow() {
-        const metaEl = document.querySelector('meta[name="rk:start-date"]');
-        if (!metaEl) return;
+        if (!day1Input.value) return;
 
-        const day1Date = parseLocalDate(metaEl.getAttribute('content'));
+        const day1Date = parseLocalDate(day1Input.value);
         const today = todayInJST();
         const todayDayNum = calculateDayNumber(day1Date, today);
 
@@ -303,6 +302,7 @@
 
       function onUserChange() {
         update();
+        updateTodayRow();
         updateQueryParam(currentInput.value);
       }
 


### PR DESCRIPTION
When a user changed the "Day 1" date input, the "(Today)" row in the reference table was not updated.

This commit fixes the issue by:
- Modifying the event handler to trigger an update for the "Today" row.
- Ensuring the calculation uses the current value from the "Day 1" input field instead of a static meta tag.

Co-Authored-By: gemini-cli